### PR TITLE
fix: sensor kit base link z value

### DIFF
--- a/individual_params/config/golf/golf_sensor_kit/sensors_calibration.yaml
+++ b/individual_params/config/golf/golf_sensor_kit/sensors_calibration.yaml
@@ -2,7 +2,7 @@ base_link:
   sensor_kit_base_link:
     x: 1.310
     y: 0.08
-    z: 1.38
+    z: 1.70
     roll: 0.0
     pitch: 0.0
     yaw: -0.023


### PR DESCRIPTION
## Description

<!-- Write a brief description of this PR. -->
The z value of sensor base link was wrong.

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
